### PR TITLE
fix loader export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ function createInjectorFunction(_ref, source) {
 
 function inject(source) {
   this.cacheable && this.cacheable();
-  return createInjectorFunction(this, source);
+  return 'module.exports = ' + createInjectorFunction(this, source);
 }
 
 module.exports = inject;


### PR DESCRIPTION
as @zincli noted in #18, this fixes the 'didn't return a function' error.