### PR TITLE
Feature/optional validation

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -43,7 +43,8 @@ describe('inject-loader', function() {
     context = {
       query: '',
       resourcePath: '',
-      cacheable: () => true
+      cacheable: () => true,
+      options: {}
     }
     injectFn = inject.bind(context)
   })

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,8 +18,14 @@ var __INJECTED_SOURCE_REGEX = new RegExp(/\$__INJECTED_SOURCE__;/);
 
 var __WRAPPED_MODULE_DEPENDENCIES_REGEX = new RegExp(/\$__WRAPPED_MODULE_DEPENDENCIES__;/);
 var __WRAPPED_MODULE_REPLACEMENT = '(__injection("$1") || require("$1"))';
+var __OPTIONS_REPLACEMENT_REGEX = /\$__INJECTED_OPTIONS__;/;
 
-function __createInjectorFunction(_ref, source) {
+var defaultOptions = {
+  validate: "error",
+  exportInjected: false
+};
+
+function __createInjectorFunction(_ref, source, configOptions) {
   var query = _ref.query,
       resourcePath = _ref.resourcePath;
 
@@ -27,6 +33,7 @@ function __createInjectorFunction(_ref, source) {
   var requireStringRegex = (0, _createRequireStringRegex2.default)(query);
   var wrappedModuleDependencies = (0, _getAllModuleDependencies2.default)(source, requireStringRegex);
   var dependencyInjectedSource = source.replace(requireStringRegex, __WRAPPED_MODULE_REPLACEMENT);
+  var options = Object.assign({}, defaultOptions, configOptions);
 
   if (wrappedModuleDependencies.length === 0) console.warn('Inject Loader: The module you are trying to inject into (`' + resourcePath + '`) does not seem to have any dependencies, are you sure you want to do this?');
 
@@ -37,19 +44,43 @@ function __createInjectorFunction(_ref, source) {
     var exports = module.exports;
 
     // $FlowIgnore
+    var options = $__INJECTED_OPTIONS__;
+
+    // $FlowIgnore
     var __wrappedModuleDependencies = $__WRAPPED_MODULE_DEPENDENCIES__;
 
-    (function __validateInjection() {
-      var injectionKeys = Object.keys(__injections);
-      var invalidInjectionKeys = injectionKeys.filter(function (x) {
-        return __wrappedModuleDependencies.indexOf(x) === -1;
-      });
+    var __injected__ = void 0;
 
-      if (invalidInjectionKeys.length > 0) throw new Error('One or more of the injections you passed in is invalid for the module you are attempting to inject into.\n\n- Valid injection targets for this module are: ' + __wrappedModuleDependencies.join(' ') + '\n- The following injections were passed in:     ' + injectionKeys.join(' ') + '\n- The following injections are invalid:        ' + invalidInjectionKeys.join(' ') + '\n');
-    })();
+    if (options.exportInjected) {
+      __injected__ = {};
+    }
+
+    if (options.validate) {
+      (function __validateInjection() {
+        var injectionKeys = Object.keys(__injections);
+        var invalidInjectionKeys = injectionKeys.filter(function (x) {
+          return __wrappedModuleDependencies.indexOf(x) === -1;
+        });
+
+        if (invalidInjectionKeys.length > 0) {
+          var message = 'One or more of the injections you passed in is invalid for the module you are attempting to inject into.\n\n- Valid injection targets for this module are: ' + __wrappedModuleDependencies.join(' ') + '\n- The following injections were passed in:     ' + injectionKeys.join(' ') + '\n- The following injections are invalid:        ' + invalidInjectionKeys.join(' ') + '\n';
+
+          switch (options.validate) {
+            case "error":
+              throw new Error(message);
+            case "warning":
+              console.warn(message);
+          }
+        }
+      })();
+    }
 
     function __injection(dependency) {
-      return __injections.hasOwnProperty(dependency) ? __injections[dependency] : null;
+      if (__injections.hasOwnProperty(dependency)) {
+        if (options.exportInjected) __injected__[dependency] = __injections[dependency];
+        return __injections[dependency];
+      }
+      return null;
     }
 
     /*!************************************************************************/
@@ -59,14 +90,24 @@ function __createInjectorFunction(_ref, source) {
     })();
     /*!************************************************************************/
 
+    console.log('accessible?', options.exportInjected);
+    if (options.exportInjected) {
+      if (module.exports.__esModule) {
+        module.exports.default.__injected__ = __injected__;
+      } else {
+        module.exports.__injected__ = __injected__;
+      }
+    }
+
     return module.exports;
   }
 
   // lol.
-  return ('module.exports = ' + __injectWrapper.toString()).replace(__INJECTED_SOURCE_REGEX, dependencyInjectedSource).replace(__WRAPPED_MODULE_DEPENDENCIES_REGEX, JSON.stringify(wrappedModuleDependencies) + ';');
+  return ('module.exports = ' + __injectWrapper.toString()).replace(__INJECTED_SOURCE_REGEX, dependencyInjectedSource).replace(__WRAPPED_MODULE_DEPENDENCIES_REGEX, JSON.stringify(wrappedModuleDependencies) + ';').replace(__OPTIONS_REPLACEMENT_REGEX, JSON.stringify(options) + ';');
 }
 
 module.exports = function inject(source) {
   this.cacheable && this.cacheable();
-  return __createInjectorFunction(this, source);
+  var configOptions = _loaderUtils2.default.getLoaderConfig(this, 'injectLoader');
+  return __createInjectorFunction(this, source, configOptions);
 };

--- a/script/integration_test
+++ b/script/integration_test
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 
 pushd example/webpack1-babel
-yarn && karma start
+yarn && node_modules/.bin/karma start
 popd
 
 pushd example/webpack2-babel
-yarn && karma start
+yarn && node_modules/.bin/karma start
 popd

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ type WebpackContext = {
 };
 
 function __createInjectorFunction({query, resourcePath}: WebpackContext, source: string) {
+function __createInjectorFunction(context: WebpackContext, source: string) {
   // const query = loaderUtils.parseQuery(querystring);
+  const query = context.query
+  const resourcePath = context.resourcePath
   const requireStringRegex = createRequireStringRegex(query);
   const wrappedModuleDependencies = getAllModuleDependencies(source, requireStringRegex);
   const dependencyInjectedSource = source.replace(requireStringRegex, __WRAPPED_MODULE_REPLACEMENT);

--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,13 @@ type Validate =
   | false
 
 type LoaderOptions = {
-  validate?: Validate
+  validate?: Validate,
+  exportInjected?: boolean
 }
 
 const defaultOptions: LoaderOptions = {
-  validate: "error"
+  validate: "error",
+  exportInjected: false
 }
 
 function __createInjectorFunction(context: WebpackContext, source: string) {
@@ -48,6 +50,12 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
 
     // $FlowIgnore
     const __wrappedModuleDependencies: Array<string> = $__WRAPPED_MODULE_DEPENDENCIES__;
+
+    let __injected__: any
+
+    if (options.exportInjected) {
+      __injected__ = {}
+    }
 
     if (options.validate) {
       (function __validateInjection() {
@@ -73,7 +81,11 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
     }
 
     function __injection(dependency: string): ?any {
-      return (__injections.hasOwnProperty(dependency) ? __injections[dependency] : null);
+      if (__injections.hasOwnProperty(dependency)) {
+        if (options.exportInjected) __injected__[dependency] = __injections[dependency]
+        return __injections[dependency]
+      }
+      return null
     }
 
     /*!************************************************************************/
@@ -82,6 +94,15 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
       $__INJECTED_SOURCE__;
     })();
     /*!************************************************************************/
+
+    console.log('accessible?', options.exportInjected)
+    if (options.exportInjected) {
+      if (module.exports.__esModule) {
+        module.exports.default.__injected__ = __injected__
+      } else {
+        module.exports.__injected__ = __injected__
+      }
+    }
 
     return module.exports;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,26 @@ import getAllModuleDependencies from './getAllModuleDependencies';
 const __INJECTED_SOURCE_REGEX = new RegExp(/\$__INJECTED_SOURCE__;/);
 const __WRAPPED_MODULE_DEPENDENCIES_REGEX = new RegExp(/\$__WRAPPED_MODULE_DEPENDENCIES__;/);
 const __WRAPPED_MODULE_REPLACEMENT = '(__injection("$1") || require("$1"))';
+const __OPTIONS_REPLACEMENT_REGEX = /\$__INJECTED_OPTIONS__;/
 
 type WebpackContext = {
   query: string,
   resourcePath: string
 };
 
-function __createInjectorFunction({query, resourcePath}: WebpackContext, source: string) {
+type Validate =
+  | "error"
+  | "warning"
+  | false
+
+type LoaderOptions = {
+  validate?: Validate
+}
+
+const defaultOptions: LoaderOptions = {
+  validate: "error"
+}
+
 function __createInjectorFunction(context: WebpackContext, source: string) {
   // const query = loaderUtils.parseQuery(querystring);
   const query = context.query
@@ -21,6 +34,7 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
   const requireStringRegex = createRequireStringRegex(query);
   const wrappedModuleDependencies = getAllModuleDependencies(source, requireStringRegex);
   const dependencyInjectedSource = source.replace(requireStringRegex, __WRAPPED_MODULE_REPLACEMENT);
+  const options: LoaderOptions = Object.assign({}, defaultOptions, loaderUtils.getLoaderConfig(context, 'injectLoader'))
 
   if (wrappedModuleDependencies.length === 0)
     console.warn(`Inject Loader: The module you are trying to inject into (\`${resourcePath}\`) does not seem to have any dependencies, are you sure you want to do this?`);
@@ -30,20 +44,33 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
     const exports = module.exports;
 
     // $FlowIgnore
+    const options: LoaderOptions = $__INJECTED_OPTIONS__
+
+    // $FlowIgnore
     const __wrappedModuleDependencies: Array<string> = $__WRAPPED_MODULE_DEPENDENCIES__;
 
-    (function __validateInjection() {
-      const injectionKeys = Object.keys(__injections);
-      const invalidInjectionKeys = injectionKeys.filter(x => __wrappedModuleDependencies.indexOf(x) === -1)
+    if (options.validate) {
+      (function __validateInjection() {
+        const injectionKeys = Object.keys(__injections);
+        const invalidInjectionKeys = injectionKeys.filter(x => __wrappedModuleDependencies.indexOf(x) === -1)
 
-      if (invalidInjectionKeys.length > 0)
-        throw new Error(`One or more of the injections you passed in is invalid for the module you are attempting to inject into.
+        if (invalidInjectionKeys.length > 0) {
+          const message: string = `One or more of the injections you passed in is invalid for the module you are attempting to inject into.
 
 - Valid injection targets for this module are: ${__wrappedModuleDependencies.join(' ')}
 - The following injections were passed in:     ${injectionKeys.join(' ')}
 - The following injections are invalid:        ${invalidInjectionKeys.join(' ')}
-`)
-    })();
+`
+
+          switch (options.validate) {
+            case "error":
+              throw new Error(message)
+            case "warning":
+              console.warn(message)
+          }
+        }
+      })();
+    }
 
     function __injection(dependency: string): ?any {
       return (__injections.hasOwnProperty(dependency) ? __injections[dependency] : null);
@@ -62,7 +89,8 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
   // lol.
   return `module.exports = ${__injectWrapper.toString()}`
     .replace(__INJECTED_SOURCE_REGEX, dependencyInjectedSource)
-    .replace(__WRAPPED_MODULE_DEPENDENCIES_REGEX, `${JSON.stringify(wrappedModuleDependencies)};`);
+    .replace(__WRAPPED_MODULE_DEPENDENCIES_REGEX, `${JSON.stringify(wrappedModuleDependencies)};`)
+    .replace(__OPTIONS_REPLACEMENT_REGEX, `${JSON.stringify(options)};`);
 }
 
 module.exports = function inject(source: string): string {

--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,12 @@ const defaultOptions: LoaderOptions = {
   exportInjected: false
 }
 
-function __createInjectorFunction(context: WebpackContext, source: string) {
+function __createInjectorFunction({ query, resourcePath }: WebpackContext, source: string, configOptions: LoaderOptions) {
   // const query = loaderUtils.parseQuery(querystring);
-  const query = context.query
-  const resourcePath = context.resourcePath
   const requireStringRegex = createRequireStringRegex(query);
   const wrappedModuleDependencies = getAllModuleDependencies(source, requireStringRegex);
   const dependencyInjectedSource = source.replace(requireStringRegex, __WRAPPED_MODULE_REPLACEMENT);
-  const options: LoaderOptions = Object.assign({}, defaultOptions, loaderUtils.getLoaderConfig(context, 'injectLoader'))
+  const options: LoaderOptions = Object.assign({}, defaultOptions, configOptions)
 
   if (wrappedModuleDependencies.length === 0)
     console.warn(`Inject Loader: The module you are trying to inject into (\`${resourcePath}\`) does not seem to have any dependencies, are you sure you want to do this?`);
@@ -116,5 +114,6 @@ function __createInjectorFunction(context: WebpackContext, source: string) {
 
 module.exports = function inject(source: string): string {
   this.cacheable && this.cacheable();
-  return __createInjectorFunction(this, source);
+  const configOptions: LoaderOptions = loaderUtils.getLoaderConfig(this, 'injectLoader')
+  return __createInjectorFunction(this, source, configOptions);
 }


### PR DESCRIPTION
* Add config loader
* Add option to not validate (invalid dependencies will be ignored, or just log a warning depending on option)
* Add option to export module with __injected__ property that contains injected modules for that module. 
* Added `options` to unit tests context mock
* Fixed integration tests, by making them use project karma install rather than global.