### PR TITLE
set compact to false and provide filename to babel

### DIFF
--- a/src/injectify.js
+++ b/src/injectify.js
@@ -12,7 +12,12 @@ function processRequireCall(path) {
 }
 
 export default function injectify(context, source, inputSourceMap) {
-  const { ast } = transform(source);
+  const { ast } = transform(source, {
+    babelrc: false,
+    code: false,
+    compact: false,
+    filename: context.resourcePath,
+  });
 
   const dependencies = [];
   traverse(ast, {
@@ -40,5 +45,8 @@ export default function injectify(context, source, inputSourceMap) {
     sourceMaps: context.sourceMap,
     sourceFileName: context.resourcePath,
     inputSourceMap,
+    babelrc: false,
+    compact: false,
+    filename: context.resourcePath,
   });
 }


### PR DESCRIPTION
First off, thank you for all your hard work on this loader; it's been a lifesaver during our requirejs -> webpack transition!

I just started instrumenting my code with [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) and I started receiving these warnings:
```
[BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "500KB".
```

I tracked it back to when I use `inject-loader` on one of our larger modules (which is now even larger as it includes the code coverage instrumentation). By default, the [`compact` option](https://babeljs.io/docs/usage/api/#options) is set to `auto`:
> Do not include superfluous whitespace characters and line terminators.
> When set to "auto" compact is set to true on input sizes of >500KB.

I'd like to explicitly set this option to something other than `auto`. Right now, this PR sets it to `false` to reflect how this behaves the majority of the time (assuming most people aren't using inject-loader on >500KB files). `true` works as well and it would mean there's less work for babel to do when it transforms the AST back into code.

Aside from the compact option, I also added the `filename` option to assist in debugging Babel messages like the one I encountered (without the filename, it falls back to "unknown"). Adding `filename` means we also have to set `babelrc: false` to prevent it from trying to look up an external config file (which can interfere with inject-loader).